### PR TITLE
Upgrade to elm-review 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,27 +15,31 @@ from being assigned `Float` types.
 For example, the following two Record type definitions would be marked as
 Errors:
 
-    type alias Foo =
-        { qux : Qux
-        , someId : Float
-        }
+```elm
+type alias Foo =
+    { qux : Qux
+    , someId : Float
+    }
 
-    type alias Bar =
-        { qux : Qux
-        , id : Float
-        }
-
+type alias Bar =
+    { qux : Qux
+    , id : Float
+    }
+```
 
 ## Usage
 
 After adding [`elm-review`][elm-review] to your project, import this rule from
 your `ReviewConfig.elm` file and add it to the config. E.g.:
 
-    import NoFloatIds
-    import Review.Rule exposing (Rule)
+```elm
+import NoFloatIds
+import Review.Rule exposing (Rule)
 
-    config : List Rule
-    config =
-        [ NoFloatIds.rule ]
+
+config : List Rule
+config =
+    [ NoFloatIds.rule ]
+```
 
 [elm-review]: https://package.elm-lang.org/packages/jfmengels/elm-review/latest/

--- a/elm.json
+++ b/elm.json
@@ -1,22 +1,17 @@
 {
     "type": "package",
     "name": "r-k-b/no-float-ids",
-    "version": "1.0.0",
     "summary": "A rule for elm-review that discourages Float types for \"Id\"s.",
     "license": "BSD-3-Clause",
+    "version": "1.0.0",
     "exposed-modules": [
         "NoFloatIds"
     ],
-    "source-directories": [
-        "src"
-    ],
-    "elm-version": "0.19.1 <= v < 0.20.0",
+    "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
-        "elm/browser": "1.0.2 <= v < 2.0.0",
         "elm/core": "1.0.5 <= v < 2.0.0",
-        "elm/html": "1.0.0 <= v < 2.0.0",
-        "jfmengels/elm-review": "1.0.0 <= v < 3.0.0",
-        "stil4m/elm-syntax": "7.1.1 <= v < 8.0.0"
+        "jfmengels/elm-review": "2.2.0 <= v < 3.0.0",
+        "stil4m/elm-syntax": "7.1.3 <= v < 8.0.0"
     },
     "test-dependencies": {
         "elm-explorations/test": "1.2.2 <= v < 2.0.0"

--- a/example/elm.json
+++ b/example/elm.json
@@ -1,0 +1,37 @@
+{
+    "type": "application",
+    "source-directories": [
+        "src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/core": "1.0.5",
+            "jfmengels/elm-review": "2.2.0",
+            "r-k-b/no-float-ids": "1.0.1"
+        },
+        "indirect": {
+            "elm/html": "1.0.0",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/project-metadata-utils": "1.0.1",
+            "elm/random": "1.0.0",
+            "elm/time": "1.0.0",
+            "elm/url": "1.0.0",
+            "elm/virtual-dom": "1.0.2",
+            "elm-community/json-extra": "4.3.0",
+            "elm-community/list-extra": "8.2.4",
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-hex": "1.0.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3",
+            "stil4m/elm-syntax": "7.1.3",
+            "stil4m/structured-writer": "1.0.3"
+        }
+    },
+    "test-dependencies": {
+        "direct": {
+            "elm-explorations/test": "1.2.2"
+        },
+        "indirect": {}
+    }
+}

--- a/example/src/ReviewConfig.elm
+++ b/example/src/ReviewConfig.elm
@@ -1,0 +1,21 @@
+module ReviewConfig exposing (config)
+
+{-| Do not rename the ReviewConfig module or the config function, because
+`elm-review` will look for these.
+
+To add packages that contain rules, add them to this review project using
+
+    `elm install author/packagename`
+
+when inside the directory containing this file.
+
+-}
+
+import NoFloatIds
+import Review.Rule exposing (Rule)
+
+
+config : List Rule
+config =
+    [ NoFloatIds.rule
+    ]

--- a/src/NoFloatIds.elm
+++ b/src/NoFloatIds.elm
@@ -63,11 +63,9 @@ But not the third:
 -}
 rule : Rule
 rule =
-    -- Define the rule with the same name as the module it is defined in
-    Rule.newSchema "NoFloatIds"
-        -- Make it look at declarations
+    Rule.newModuleRuleSchema "NoFloatIds" ()
         |> Rule.withSimpleDeclarationVisitor declarationVisitor
-        |> Rule.fromSchema
+        |> Rule.fromModuleRuleSchema
 
 
 details =
@@ -85,7 +83,7 @@ details =
     }
 
 
-declarationVisitor : Node Declaration -> List Error
+declarationVisitor : Node Declaration -> List (Error {})
 declarationVisitor node =
     case Node.value node of
         FunctionDeclaration _ ->
@@ -130,7 +128,7 @@ declarationVisitor node =
             []
 
 
-checkForFloatIds : Node RecordField -> List Error
+checkForFloatIds : Node RecordField -> List (Error {})
 checkForFloatIds recordDefinition =
     let
         ( nameNode, typeAnno ) =


### PR DESCRIPTION
Update dependencies and rule code to work with elm-review 2.x.  Also adds an `example/` config ready for [elm-review@2.3.0](https://github.com/jfmengels/node-elm-review/releases/tag/v2.3.0-beta.1)'s upcoming `--template` feature.